### PR TITLE
Stable post-data-collection data quality test

### DIFF
--- a/data_analysis/visualization/annotation_parameters.yaml
+++ b/data_analysis/visualization/annotation_parameters.yaml
@@ -12,5 +12,5 @@ annotation:
 
 
 directory:
-  image_directory: "/hdd01/eye_images/2021_07_05_15_25_46/"
-  saving_directory: "/hdd01/eye_images/Final_eye_images/Bates_labels/"
+  image_directory: "/home/veddy06/Downloads/S5_shade/"
+  saving_directory: "/home/veddy06/Downloads/S5_shade_output/"

--- a/demos/test_data_quality.py
+++ b/demos/test_data_quality.py
@@ -316,8 +316,10 @@ def run_pupil_detection_PL(session, number_of_frames=250):
             prev_frame_0 = np.array(img_0, dtype=np.float64)
             prev_frame_1 = np.array(img_1, dtype=np.float64)
         else:
-            sum_0 = (img_0 + prev_frame_0)/2.0
-            sum_1 = (img_1 + prev_frame_1)/2.0
+            if(pupil0_dict_2d["confidence"]) > 0.5:
+                sum_0 = (img_0 + prev_frame_0)/2.0
+            if (pupil1_dict_2d["confidence"]) > 0.5:
+                sum_1 = (img_1 + prev_frame_1)/2.0
 
         pupil0_dict_2d = detector_2D.detect(np.ascontiguousarray(img_0))
         df["pupil_timestamp"].loc[count] = eye0_timestamp[frame_index]


### PR DESCRIPTION
The test_data_quality.py under the demos folder runs a quick test on a recording session and it generates images accordingly.

- Pupil detection over 1500 right and left eye images and generates pupil confidence plots
- Generates average right and left eye images for 1500 random frames across the recording session
- Circle and checkerboard marker detection over the calibration and validation frames
- Generates scatter plots and also the image snippet for each successful detection frame